### PR TITLE
Handle bind callback

### DIFF
--- a/include/smpp.hrl
+++ b/include/smpp.hrl
@@ -9,3 +9,4 @@
 -include_lib("smpp34pdu/include/smpp34pdu.hrl").
 
 -define(DEFAULT_PORT, 2775).
+-define(DEFAULT_IP, {0,0,0,0}).

--- a/src/gen_smsc.erl
+++ b/src/gen_smsc.erl
@@ -42,12 +42,17 @@
 -type send_reply() :: smpp_socket:send_reply().
 -type event_type() :: gen_statem:event_type().
 -type from() :: {pid(), term()}. %% gen_statem:from()
+-type bind_pdu() :: bind_receiver() | bind_transceiver() | bind_transmitter().
+-type bind_resp() :: bind_receiver_resp() | bind_transceiver_resp() | bind_transmitter_resp().
 
 -export_type([state/0, error_reason/0, statename/0, send_reply/0, send_callback/0]).
 -export_type([event_type/0, from/0]).
 
 -callback handle_connected(state()) -> state() | ignore.
 -callback handle_disconnected(error_reason(), statename(), state()) -> state() | ignore.
+-callback handle_bind(bind_pdu(), state()) -> {non_neg_integer(), state()} |
+                                     {non_neg_integer(), bind_resp(), state()} |
+                                     ignore.
 -callback handle_bound(state()) -> state() | ignore.
 -callback handle_deliver(deliver_sm(), state()) -> {non_neg_integer(), state()} |
                                                    {non_neg_integer(), deliver_sm_resp(), state()} |
@@ -61,6 +66,7 @@
 %% All callbacks are optional
 -optional_callbacks([handle_connected/1,
                      handle_disconnected/3,
+                     handle_bind/2,
                      handle_bound/1,
                      handle_deliver/2,
                      handle_submit/2,

--- a/src/gen_smsc.erl
+++ b/src/gen_smsc.erl
@@ -135,11 +135,12 @@ pp(Term) ->
 -spec opts_to_state(module() | undefined, map()) -> {state(), ranch_tcp:opts()}.
 opts_to_state(Mod, Opts) ->
     Port = maps:get(port, Opts, ?DEFAULT_PORT),
+    IP = maps:get(ip, Opts, ?DEFAULT_IP),
     RQLimit = maps:get(request_queue_limit, Opts, ?REQUEST_QUEUE_LIMIT),
     KeepAliveTimeout = maps:get(keepalive_timeout, Opts, ?KEEPALIVE_TIMEOUT),
     BindTimeout = maps:get(bind_timeout, Opts, ?BIND_TIMEOUT),
     IsProxy = maps:get(proxy, Opts, false),
-    RanchOpts = [{port, Port}],
+    RanchOpts = [{ip, IP}, {port, Port}],
     State = Opts#{rq_limit => RQLimit,
                   reconnect => false,
                   proxy => IsProxy,


### PR DESCRIPTION
Current gen_smsc implementation has no callback which could check bind requests.  
This PR introduces `handle_bind` callback, which accepts `bind_transceiver/bind_receiver/bind_transmitter` messages and answers with appropriate response message.
This can be useful for limiting connection per link or implementing authorization.