### PR TITLE
add handle_sending callback to gen_esme behaviour

### DIFF
--- a/src/gen_esme.erl
+++ b/src/gen_esme.erl
@@ -54,6 +54,7 @@
 -callback handle_connected(state()) -> state() | ignore.
 -callback handle_disconnected(error_reason(), statename(), state()) -> state() | ignore.
 -callback handle_bound(state()) -> state() | ignore.
+-callback handle_sending(submit_sm(), state()) -> any().
 -callback handle_deliver(deliver_sm(), state()) -> {non_neg_integer(), state()} |
                                                    {non_neg_integer(), deliver_sm_resp(), state()} |
                                                    ignore.
@@ -67,6 +68,7 @@
 -optional_callbacks([handle_connected/1,
                      handle_disconnected/3,
                      handle_bound/1,
+                     handle_sending/2,
                      handle_deliver/2,
                      handle_submit/2,
                      handle_event/4,

--- a/src/smpp_socket.erl
+++ b/src/smpp_socket.erl
@@ -628,6 +628,13 @@ send_req(#{in_flight := InFlight} = State, Body, Sender, Time) ->
     Seq = (maps:get(seq, State, 0) rem 16#7FFFFFFF) + 1,
     RespDeadline = current_time() + maps:get(keepalive_timeout, State),
     State1 = State#{seq => Seq, in_flight => [{Seq, {Time, RespDeadline, Sender}} | InFlight]},
+    case Body of
+        #submit_sm{} ->
+            _ = callback(handle_sending, Body, State),
+            ok;
+        _ ->
+            ok
+    end,
     send_pkt(State1, ?ESME_ROK, Seq, Body),
     State2 = unset_keepalive_timeout(State1, esme),
     set_request_timeout(State2).


### PR DESCRIPTION
In our ESME implementations currently we count "send_request" metrics before calling `gen_esme:send_async()`. This metric is not correct, because actual sending happens only in future, not here and now. So I'm adding callback `handle_sending` to `gen_esme` behaviour to run callback before actual outgoing packet transmission to SMSC.