### PR TITLE
BP-136: introduce response_timeout opt separated from keepalive_timeout

### DIFF
--- a/src/gen_esme.erl
+++ b/src/gen_esme.erl
@@ -160,6 +160,7 @@ opts_to_state(Mod, Opts) ->
     ConnectTimeout = maps:get(connect_timeout, Opts, ?CONNECT_TIMEOUT),
     ReconnectTimeout = maps:get(reconnect_timeout, Opts, ?RECONNECT_TIMEOUT),
     KeepAliveTimeout = maps:get(keepalive_timeout, Opts, ?KEEPALIVE_TIMEOUT),
+    ResponseTimeout = maps:get(response_timeout, Opts, KeepAliveTimeout),
     BindTimeout = maps:get(bind_timeout, Opts, ?BIND_TIMEOUT),
     ReqPerSec = maps:get(req_per_sec, Opts, undefined),
     MaxAwaitReqs = maps:get(max_await_reqs, Opts, undefined),
@@ -177,7 +178,8 @@ opts_to_state(Mod, Opts) ->
                   bind_timeout => BindTimeout,
                   req_per_sec => ReqPerSec,
                   max_await_reqs => MaxAwaitReqs,
-                  keepalive_timeout => KeepAliveTimeout},
+                  keepalive_timeout => KeepAliveTimeout,
+                  response_timeout => ResponseTimeout},
     case Mod of
         undefined ->
             State;

--- a/src/gen_smsc.erl
+++ b/src/gen_smsc.erl
@@ -138,6 +138,7 @@ opts_to_state(Mod, Opts) ->
     IP = maps:get(ip, Opts, ?DEFAULT_IP),
     RQLimit = maps:get(request_queue_limit, Opts, ?REQUEST_QUEUE_LIMIT),
     KeepAliveTimeout = maps:get(keepalive_timeout, Opts, ?KEEPALIVE_TIMEOUT),
+    ResponseTimeout = maps:get(response_timeout, Opts, KeepAliveTimeout),
     BindTimeout = maps:get(bind_timeout, Opts, ?BIND_TIMEOUT),
     IsProxy = maps:get(proxy, Opts, false),
     RanchOpts = [{ip, IP}, {port, Port}],
@@ -145,7 +146,8 @@ opts_to_state(Mod, Opts) ->
                   reconnect => false,
                   proxy => IsProxy,
                   bind_timeout => BindTimeout,
-                  keepalive_timeout => KeepAliveTimeout},
+                  keepalive_timeout => KeepAliveTimeout,
+                  response_timeout => ResponseTimeout},
     case Mod of
         undefined ->
             {State, RanchOpts};


### PR DESCRIPTION
Introduce response_timeout option separated from keepalive_timeout. This will allow setting timeout for request processing different from the keepalive logic.