### PR TITLE
Fix invalid guard in submit_sm handling for smsc

### DIFF
--- a/src/smpp_socket.erl
+++ b/src/smpp_socket.erl
@@ -48,6 +48,7 @@
 -define(is_request(CmdID), ((CmdID band 16#80000000) == 0)).
 -define(is_response(CmdID), ((CmdID band 16#80000000) /= 0)).
 -define(is_receiver(Mode), (Mode == receiver orelse Mode == transceiver)).
+-define(is_transmitter(Mode), (Mode == transmitter orelse Mode == transceiver)).
 
 -type state() :: #{vsn := non_neg_integer(),
                    id := term(),
@@ -522,7 +523,7 @@ handle_request(#pdu{body = #deliver_sm{} = Body} = Pkt, _,
     {ok, State2};
 handle_request(#pdu{body = #submit_sm{} = Body} = Pkt, _,
                #{role := Role, mode := Mode, proxy := Proxy} = State)
-  when ?is_receiver(Mode) andalso (Role == smsc orelse Proxy == true) ->
+  when ?is_transmitter(Mode) andalso (Role == smsc orelse Proxy == true) ->
     {Status, Resp, State1} = callback(handle_submit, Body, State),
     State2 = send_resp(State1, Resp, Pkt, Status),
     {ok, State2};


### PR DESCRIPTION
There is an error in guard in `handle_request` function for smsc.  
Current guard for this clause in smsc checks if esme mode is receiver or transmitter for handling submit_sm, however it should check if esme mode is transmitter or transceiver.
This PR fixes that error.