### PR TITLE
USSD-411: data_sm support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,6 @@
-{deps, [{smpp34pdu, ".*", {git, "https://github.com/bdt-group/smpp34pdu.git", {branch, "feature/USSD-411/ussd-TLV-for-data_sm"}}},
+{deps, [{smpp34pdu, ".*", {git,
+                           "https://github.com/bdt-group/smpp34pdu.git",
+                           {branch, "feature/USSD-411/ussd-TLV-for-data_sm"}}},
         {ranch, ".*", {git, "https://github.com/ninenines/ranch.git", {tag, "2.0.0"}}}]}.
 
 {erl_opts,

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [{smpp34pdu, ".*", {git, "https://github.com/bdt-group/smpp34pdu.git", {branch, "master"}}},
+{deps, [{smpp34pdu, ".*", {git, "https://github.com/bdt-group/smpp34pdu.git", {branch, "feature/USSD-411/ussd-TLV-for-data_sm"}}},
         {ranch, ".*", {git, "https://github.com/ninenines/ranch.git", {tag, "2.0.0"}}}]}.
 
 {erl_opts,

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,4 @@
-{deps, [{smpp34pdu, ".*", {git,
-                           "https://github.com/bdt-group/smpp34pdu.git",
-                           {branch, "feature/USSD-411/ussd-TLV-for-data_sm"}}},
+{deps, [{smpp34pdu, ".*", {git, "https://github.com/bdt-group/smpp34pdu.git", {branch, "master"}}},
         {ranch, ".*", {git, "https://github.com/ninenines/ranch.git", {tag, "2.0.0"}}}]}.
 
 {erl_opts,

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,5 +4,5 @@
   0},
  {<<"smpp34pdu">>,
   {git,"https://github.com/bdt-group/smpp34pdu.git",
-       {ref,"59024954b008b6af6efeb3d2f39c6d46c6c1e6a1"}},
+       {ref,"67f2662bd25f92796525e3da14450ebc82822d05"}},
   0}].

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,5 +4,5 @@
   0},
  {<<"smpp34pdu">>,
   {git,"https://github.com/bdt-group/smpp34pdu.git",
-       {ref,"5587817c256af01259dca09846dfe3e27edc382f"}},
+       {ref,"3baf797eff1ba40dbd21f7631288cbbd884e59f3"}},
   0}].

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,5 +4,5 @@
   0},
  {<<"smpp34pdu">>,
   {git,"https://github.com/bdt-group/smpp34pdu.git",
-       {ref,"67f2662bd25f92796525e3da14450ebc82822d05"}},
+       {ref,"5587817c256af01259dca09846dfe3e27edc382f"}},
   0}].

--- a/src/gen_esme.erl
+++ b/src/gen_esme.erl
@@ -61,6 +61,9 @@
 -callback handle_submit(submit_sm(), state()) -> {non_neg_integer(), state()} |
                                                  {non_neg_integer(), submit_sm_resp(), state()} |
                                                  ignore.
+-callback handle_data(data_sm(), state()) -> {non_neg_integer(), state()} |
+                                             {non_neg_integer(), data_sm_resp(), state()} |
+                                             ignore.
 -callback handle_stop(term(), statename(), state()) -> any().
 -callback handle_event(event_type(), term(), statename(), state()) -> state() | ignore.
 
@@ -70,6 +73,7 @@
                      handle_bound/1,
                      handle_sending/2,
                      handle_deliver/2,
+                     handle_data/2,
                      handle_submit/2,
                      handle_event/4,
                      handle_stop/3]).

--- a/src/gen_smsc.erl
+++ b/src/gen_smsc.erl
@@ -60,6 +60,9 @@
 -callback handle_submit(submit_sm(), state()) -> {non_neg_integer(), state()} |
                                                  {non_neg_integer(), submit_sm_resp(), state()} |
                                                  ignore.
+-callback handle_data(data_sm(), state()) -> {non_neg_integer(), state()} |
+                                             {non_neg_integer(), data_sm_resp(), state()} |
+                                             ignore.
 -callback handle_cancel(cancel_sm(), state()) -> {non_neg_integer(), state()} |
                                                  {non_neg_integer(), cancel_sm_resp(), state()} |
                                                  ignore.

--- a/src/smpp_socket.erl
+++ b/src/smpp_socket.erl
@@ -212,8 +212,7 @@ send(Ref, Pkt, Timeout) ->
             try gen_statem:call(Ref, {send_req, Pkt, Time}, {dirty_timeout, Timeout})
             catch exit:{timeout, {gen_statem, call, _}} ->
                     {error, timeout};
-                  exit:{_, {gen_statem, call, _}} = Err ->
-                    ct:pal("~p", [Err]),
+                  exit:{_, {gen_statem, call, _}} ->
                     {error, closed}
             end;
         error ->
@@ -862,7 +861,6 @@ callback(Fun, State) ->
 
 -spec callback(atom(), valid_pdu(), state()) -> {non_neg_integer(), valid_pdu(), state()}.
 callback(Fun, Body, #{callback := Mod} = State) ->
-    ct:pal("Exp: ~p ~p ~p", [Mod, Fun, erlang:function_exported(Mod, Fun, 2)]),
     case erlang:function_exported(Mod, Fun, 2) of
         false -> default_callback(Fun, Body, State);
         true ->

--- a/test/echo_smsc.erl
+++ b/test/echo_smsc.erl
@@ -43,6 +43,7 @@ echo_submit_sm(#submit_sm{source_addr_ton = DestAddrTon,
                 dest_addr_npi = DestAddrNpi,
                 destination_addr = DestAddr,
                 short_message = ShortMessage}.
+
 echo_data_sm(#data_sm{source_addr_ton = DestAddrTon,
                           source_addr_npi = DestAddrNpi,
                           source_addr = DestAddr,

--- a/test/echo_smsc.erl
+++ b/test/echo_smsc.erl
@@ -4,7 +4,7 @@
 
 -behaviour(gen_smsc).
 
--export([start/2, stop/1, handle_submit/2, handle_cancel/2]).
+-export([start/2, stop/1, handle_submit/2, handle_cancel/2, handle_data/2]).
 
 %%%===================================================================
 %%% API
@@ -17,6 +17,10 @@ stop(Ref) ->
 
 handle_submit(SubmitSm, State) ->
     ok = gen_smsc:send_async(self(), echo_submit_sm(SubmitSm)),
+    {?ESME_ROK, State}.
+
+handle_data(DataSm, State) ->
+    ok = gen_smsc:send_async(self(), echo_data_sm(DataSm)),
     {?ESME_ROK, State}.
 
 handle_cancel(_Cancel, State) ->
@@ -39,3 +43,17 @@ echo_submit_sm(#submit_sm{source_addr_ton = DestAddrTon,
                 dest_addr_npi = DestAddrNpi,
                 destination_addr = DestAddr,
                 short_message = ShortMessage}.
+echo_data_sm(#data_sm{source_addr_ton = DestAddrTon,
+                          source_addr_npi = DestAddrNpi,
+                          source_addr = DestAddr,
+                          dest_addr_ton = SrcAddrTon,
+                          dest_addr_npi = SrcAddrNpi,
+                          destination_addr = SrcAddr,
+                          message_payload = MessagePayload}) ->
+    #data_sm{source_addr_ton = SrcAddrTon,
+                source_addr_npi = SrcAddrNpi,
+                source_addr = SrcAddr,
+                dest_addr_ton = DestAddrTon,
+                dest_addr_npi = DestAddrNpi,
+                destination_addr = DestAddr,
+                message_payload = MessagePayload}.

--- a/test/test_esme_1.erl
+++ b/test/test_esme_1.erl
@@ -4,7 +4,7 @@
 
 -behaviour(gen_esme).
 
--export([start/2, stop/1, handle_deliver/2]).
+-export([start/2, stop/1, handle_deliver/2, handle_data/2]).
 
 %%%===================================================================
 %%% API
@@ -18,3 +18,8 @@ stop(Ref) ->
 handle_deliver(DeliverSm, State = #{subscriber := Pid}) ->
     Pid ! DeliverSm,
     {?ESME_ROK, State}.
+
+handle_data(DataSm, State = #{subscriber := Pid}) ->
+    ct:pal("rec data_sm: ~p", [DataSm]),
+    Pid ! DataSm,
+    {?ESME_ROK, #data_sm_resp{}, State}.


### PR DESCRIPTION
This PR adds data_sm processing capability to esme and smsc behaviours via optional `handle_data` callback. `data_sm` can be used as an alternative to `deliver_sm` for incoming ussd requests.