### PR TITLE
USSD-434: introduce response_timeout tolerance flag

### DIFF
--- a/src/gen_esme.erl
+++ b/src/gen_esme.erl
@@ -173,7 +173,7 @@ opts_to_state(Mod, Opts) ->
     BindTimeout = maps:get(bind_timeout, Opts, ?BIND_TIMEOUT),
     ReqPerSec = maps:get(req_per_sec, Opts, undefined),
     MaxAwaitReqs = maps:get(max_await_reqs, Opts, undefined),
-    TimeoutTolerance = maps:get(timeout_tolerance, Opts, false),
+    IgnoreResponseTimeout = maps:get(ignore_response_timeout, Opts, false),
     State = Opts#{host => Host,
                   port => Port,
                   mode => Mode,
@@ -192,7 +192,7 @@ opts_to_state(Mod, Opts) ->
                   max_await_reqs => MaxAwaitReqs,
                   keepalive_timeout => KeepAliveTimeout,
                   response_timeout => ResponseTimeout,
-                  timeout_tolerance => TimeoutTolerance},
+                  ignore_response_timeout => IgnoreResponseTimeout},
     case Mod of
         undefined ->
             State;

--- a/src/gen_esme.erl
+++ b/src/gen_esme.erl
@@ -173,6 +173,7 @@ opts_to_state(Mod, Opts) ->
     BindTimeout = maps:get(bind_timeout, Opts, ?BIND_TIMEOUT),
     ReqPerSec = maps:get(req_per_sec, Opts, undefined),
     MaxAwaitReqs = maps:get(max_await_reqs, Opts, undefined),
+    TimeoutTolerance = maps:get(timeout_tolerance, Opts, false),
     State = Opts#{host => Host,
                   port => Port,
                   mode => Mode,
@@ -190,7 +191,8 @@ opts_to_state(Mod, Opts) ->
                   req_per_sec => ReqPerSec,
                   max_await_reqs => MaxAwaitReqs,
                   keepalive_timeout => KeepAliveTimeout,
-                  response_timeout => ResponseTimeout},
+                  response_timeout => ResponseTimeout,
+                  timeout_tolerance => TimeoutTolerance},
     case Mod of
         undefined ->
             State;

--- a/src/smpp_socket.erl
+++ b/src/smpp_socket.erl
@@ -80,6 +80,7 @@
                    socket => port(),
                    transport => module(),
                    current_rps => {millisecs(), non_neg_integer()},
+                   timeout_tolerance => boolean(),
                    _ => term()}.
 
 -type seq() :: non_neg_integer().
@@ -344,6 +345,9 @@ bound(info, {tcp_error, Sock, Reason}, #{socket := Sock} = State) ->
     reconnect({inet, Reason}, ?FUNCTION_NAME, State);
 bound(timeout, keepalive, #{role := esme} = State) ->
     State1 = send_req(State, #enquire_link{}),
+    keep_state(State1);
+bound(timeout, _, #{timeout_tolerance := true} = State) ->
+    State1 = handle_send_timeout(State),
     keep_state(State1);
 bound(timeout, _, State) ->
     reconnect(timeout, ?FUNCTION_NAME, State);
@@ -776,6 +780,18 @@ current_time() ->
 init_state(State, Role) ->
     State#{vsn => ?VSN, role => Role,
            in_flight => []}.
+
+-spec handle_send_timeout(state()) -> state().
+handle_send_timeout(#{in_flight := []} = State) ->
+    State;
+handle_send_timeout(#{in_flight := InFlight} = State) ->
+    Now = current_time(),
+    {InFlight1, Timeouted} = lists:splitwith(fun({_, {_, RespDeadline, _}}) ->
+                                                     RespDeadline < Now
+                                             end, InFlight),
+    lists:foldr(fun({_Seq, {ReqDeadline, _, Sender}}, State1) ->
+                        reply(State1, {error, timeout}, ReqDeadline, Sender)
+                end, State#{in_flight => InFlight1}, Timeouted).
 
 %%%-------------------------------------------------------------------
 %%% Timers

--- a/src/smpp_socket.erl
+++ b/src/smpp_socket.erl
@@ -80,7 +80,7 @@
                    socket => port(),
                    transport => module(),
                    current_rps => {millisecs(), non_neg_integer()},
-                   timeout_tolerance => boolean(),
+                   ignore_response_timeout => boolean(),
                    _ => term()}.
 
 -type seq() :: non_neg_integer().
@@ -346,7 +346,7 @@ bound(info, {tcp_error, Sock, Reason}, #{socket := Sock} = State) ->
 bound(timeout, keepalive, #{role := esme} = State) ->
     State1 = send_req(State, #enquire_link{}),
     keep_state(State1);
-bound(timeout, _, #{timeout_tolerance := true} = State) ->
+bound(timeout, _, #{ignore_response_timeout := true} = State) ->
     State1 = handle_send_timeout(State),
     keep_state(State1);
 bound(timeout, _, State) ->

--- a/test/smpp_SUITE.erl
+++ b/test/smpp_SUITE.erl
@@ -20,7 +20,7 @@ all() ->
      connection_repair,
      flow_control_req_per_sec,
      flow_control_in_flight,
-     timeout_tolerance].
+     ignore_response_timeout].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(ranch),
@@ -141,11 +141,11 @@ flow_control_in_flight(_Config) ->
     {ok, {?ESME_ROK, #submit_sm_resp{}}} = gen_esme:send(?ESME_REF, SubmitSm, 1000),
     ranch:stop_listener(?SMSC_REF).
 
-timeout_tolerance(_Config) ->
+ignore_response_timeout(_Config) ->
     {ok, _} = slow_echo_smsc:start(?SMSC_REF, #{}),
     {global, Id} = ?ESME_REF,
     {ok, EsmePid} = test_esme_1:start(?ESME_REF, #{subscriber => self(),
-                                                   timeout_tolerance => true,
+                                                   ignore_response_timeout => true,
                                                    response_timeout => 600,
                                                    reconnect => false,
                                                    in_flight_limit => 0,


### PR DESCRIPTION
At the moment, if there is no response correlated by sequence id for request, then connection FSM flushes all in_flight messages and free all sequences at once. However, there are unreliable SMSC's for which such eager sequence invalidation damages all in_flight requests as collateral. This PR introduces `timeout_tolerance` flag, when it's set, it allows to reply with timeouts upon response timeout only to failed requests without discarding of whole `in_flight` buffer. 